### PR TITLE
CG-14 Handle invalid tiles

### DIFF
--- a/src/pieces/king.js
+++ b/src/pieces/king.js
@@ -9,98 +9,114 @@ export class King extends Piece {
     }  
 
     // King's Moves
-    moveUp() {
+    moveUp(chessBoard) {
         const [row, col] = this._currentPosition;
         this._lastPosition = [row, col];
 
         const newRow = row + 1 * this.direction;
         const newCol = col;
 
-        return this.pieceBoundCheck(newRow, newCol);
+        const friendlyTile = this.friendlyTileCheck(newRow, newCol, chessBoard);
+
+        return friendlyTile ? null : [newRow, newCol];
     }
 
-    moveDown() {
+    moveDown(chessBoard) {
         const [row, col] = this._currentPosition;
         this._lastPosition = [row, col];
-
+chessBoard
         const newRow = row - 1 * this.direction;
         const newCol = col;
 
-        return this.pieceBoundCheck(newRow, newCol);
+        const friendlyTile = this.friendlyTileCheck(newRow, newCol, chessBoard);
+
+        return friendlyTile ? null : [newRow, newCol];
     }
 
-    moveRight() {
+    moveRight(chessBoard) {
         const [row, col] = this._currentPosition;
         this._lastPosition = [row, col];
 
         const newRow = row;
         const newCol = col + 1 * this.direction;
 
-        return this.pieceBoundCheck(newRow, newCol);
+        const friendlyTile = this.friendlyTileCheck(newRow, newCol, chessBoard);
+
+        return friendlyTile ? null : [newRow, newCol];
     }
 
-    moveLeft() {
+    moveLeft(chessBoard) {
         const [row, col] = this._currentPosition;
         this._lastPosition = [row, col];
 
         const newRow = row;
         const newCol = col - 1 * this.direction;
 
-        return this.pieceBoundCheck(newRow, newCol);
+        const friendlyTile = this.friendlyTileCheck(newRow, newCol, chessBoard);
+
+        return friendlyTile ? null : [newRow, newCol];
     }
 
     // Diagonal Moves
-    moveUpRight() {
+    moveUpRight(chessBoard) {
         const [row, col] = this._currentPosition;
         this._lastPosition = [row, col];
 
         const newRow = row - 1 * this.direction;
         const newCol = col + 1 * this.direction;
 
-        return this.pieceBoundCheck(newRow, newCol);
+        const friendlyTile = this.friendlyTileCheck(newRow, newCol, chessBoard);
+
+        return friendlyTile ? null : [newRow, newCol];
     }
 
-    moveUpLeft() {
+    moveUpLeft(chessBoard) {
         const [row, col] = this._currentPosition;
         this._lastPosition = [row, col];
 
         const newRow = row - 1 * this.direction;
         const newCol = col - 1 * this.direction;
 
-        return this.pieceBoundCheck(newRow, newCol);
+        const friendlyTile = this.friendlyTileCheck(newRow, newCol, chessBoard);
+
+        return friendlyTile ? null : [newRow, newCol];
     }
 
-    moveDownRight() {
+    moveDownRight(chessBoard) {
         const [row, col] = this._currentPosition;
         this._lastPosition = [row, col];
 
         const newRow = row + 1 * this.direction;
         const newCol = col + 1 * this.direction;
 
-        return this.pieceBoundCheck(newRow, newCol);
+        const friendlyTile = this.friendlyTileCheck(newRow, newCol, chessBoard);
+
+        return friendlyTile ? null : [newRow, newCol];
     }
 
-    moveDownLeft() {
+    moveDownLeft(chessBoard) {
         const [row, col] = this._currentPosition;
         this._lastPosition = [row, col];
 
         const newRow = row + 1 * this.direction;
         const newCol = col - 1 * this.direction;
 
-        return this.pieceBoundCheck(newRow, newCol);
+        const friendlyTile = this.friendlyTileCheck(newRow, newCol, chessBoard);
+
+        return friendlyTile ? null : [newRow, newCol];
     }
 
     // Generate all legal moves for the king
-    generateLegalMoves() {
+    generateLegalMoves(chessBoard) {
         const legalMoves = [
-            this.moveUp(),
-            this.moveDown(),
-            this.moveRight(),
-            this.moveLeft(),
-            this.moveUpRight(),
-            this.moveUpLeft(),
-            this.moveDownRight(),
-            this.moveDownLeft(),
+            this.moveUp(chessBoard),
+            this.moveDown(chessBoard),
+            this.moveRight(chessBoard),
+            this.moveLeft(chessBoard),
+            this.moveUpRight(chessBoard),
+            this.moveUpLeft(chessBoard),
+            this.moveDownRight(chessBoard),
+            this.moveDownLeft(chessBoard),
         ];
 
         // Filter out null moves (moves outside the chessboard)

--- a/src/pieces/knight.js
+++ b/src/pieces/knight.js
@@ -8,18 +8,6 @@ export class Knight extends Piece {
         super("Knight", team, startingPosition);
     }
 
-    // Check for friendlies
-    friendlyTileCheck(newRow, newCol, chessBoard) {
-        if (this.pieceBoundCheck(newRow, newCol)) {
-            const tileOccupation = chessBoard[newRow][newCol].spaceOccupation;
-
-            return tileOccupation && tileOccupation.pieceTeam === this.team;
-        }
-
-        // Return false if the position is out of bounds
-        return false;
-    }
-
     // Up and Right
     jumpUpRight(chessBoard) {
         const [row, col] = this._currentPosition;

--- a/src/pieces/knight.js
+++ b/src/pieces/knight.js
@@ -8,105 +8,133 @@ export class Knight extends Piece {
         super("Knight", team, startingPosition);
     }
 
+    // Check for friendlies
+    friendlyTileCheck(newRow, newCol, chessBoard) {
+        if (this.pieceBoundCheck(newRow, newCol)) {
+            const tileOccupation = chessBoard[newRow][newCol].spaceOccupation;
+
+            return tileOccupation && tileOccupation.pieceTeam === this.team;
+        }
+
+        // Return false if the position is out of bounds
+        return false;
+    }
+
     // Up and Right
-    jumpUpRight() {
+    jumpUpRight(chessBoard) {
         const [row, col] = this._currentPosition;
         this._lastPosition = [row, col];
 
         const newRow = row - 2 * this.direction;
         const newCol = col + 1 * this.direction;
 
-        return this.pieceBoundCheck(newRow, newCol);
+        const friendlyTile = this.friendlyTileCheck(newRow, newCol, chessBoard);
+
+        return friendlyTile ? null : [newRow, newCol];
     }
 
     // Up and Left
-    jumpUpLeft() {
+    jumpUpLeft(chessBoard) {
         const [row, col] = this._currentPosition;
         this._lastPosition = [row, col];
         
         const newRow = row - 2 * this.direction;
         const newCol = col - 1 * this.direction;
 
-        return this.pieceBoundCheck(newRow, newCol);
+        const friendlyTile = this.friendlyTileCheck(newRow, newCol, chessBoard);
+
+        return friendlyTile ? null : [newRow, newCol];
     }
 
     // Down and right
-    jumpDownRight() {
+    jumpDownRight(chessBoard) {
         const [row, col] = this._currentPosition;
         this._lastPosition = [row, col];
         
         const newRow = row + 2 * this.direction;
         const newCol = col + 1 * this.direction;
 
-        return this.pieceBoundCheck(newRow, newCol);
+        const friendlyTile = this.friendlyTileCheck(newRow, newCol, chessBoard);
+
+        return friendlyTile ? null : [newRow, newCol];
     }
 
     // Down and Left
-    jumpDownLeft() {
+    jumpDownLeft(chessBoard) {
         const [row, col] = this._currentPosition;
         this._lastPosition = [row, col];
 
         const newRow = row + 2 * this.direction;
         const newCol = col - 1 * this.direction;
 
-        return this.pieceBoundCheck(newRow, newCol);
+        const friendlyTile = this.friendlyTileCheck(newRow, newCol, chessBoard);
+
+        return friendlyTile ? null : [newRow, newCol];
     }
 
     // Right and Up
-    jumpRightUp() {
+    jumpRightUp(chessBoard) {
         const [row, col] = this._currentPosition;
         this._lastPosition = [row, col];
 
         const newRow = row - 1 * this.direction;
         const newCol = col + 2 * this.direction;
 
-        return this.pieceBoundCheck(newRow, newCol);
+        const friendlyTile = this.friendlyTileCheck(newRow, newCol, chessBoard);
+
+        return friendlyTile ? null : [newRow, newCol];
     }
 
     // Right and Down
-    jumpRightDown() {
+    jumpRightDown(chessBoard) {
         const [row, col] = this._currentPosition;
         this._lastPosition = [row, col];
 
         const newRow = row + 1 * this.direction;
         const newCol = col + 2 * this.direction;
 
-        return this.pieceBoundCheck(newRow, newCol);
+        const friendlyTile = this.friendlyTileCheck(newRow, newCol, chessBoard);
+
+        return friendlyTile ? null : [newRow, newCol];
     }
 
     // Left and Up
-    jumpLeftUp() {
+    jumpLeftUp(chessBoard) {
         const [row, col] = this._currentPosition;
         this._lastPosition = [row, col];
 
         const newRow = row - 1 * this.direction;
         const newCol = col - 2 * this.direction;
 
-        return this.pieceBoundCheck(newRow, newCol);
+        const friendlyTile = this.friendlyTileCheck(newRow, newCol, chessBoard);
+
+        return friendlyTile ? null : [newRow, newCol];
     }
 
     // Left and Down
-    jumpLeftDown() {
+    jumpLeftDown(chessBoard) {
         const [row, col] = this._currentPosition;
         this._lastPosition = [row, col];
 
         const newRow = row + 1 * this.direction;
         const newCol = col - 2 * this.direction;
 
-        return this.pieceBoundCheck(newRow, newCol);
+        const friendlyTile = this.friendlyTileCheck(newRow, newCol, chessBoard);
+
+        return friendlyTile ? null : [newRow, newCol];
     }
 
     // Generate all legal moves for the knight
-    generateLegalMoves() {
+    generateLegalMoves(chessBoard) {
         const legalMoves = [
-            this.jumpUpRight(),
-            this.jumpUpLeft(),
-            this.jumpDownRight(),
-            this.jumpDownLeft(),
-            this.jumpRightUp(),
-            this.jumpRightDown(),
-            this.jumpLeftUp(),
-            this.jumpLeftDown(),
+            this.jumpUpRight(chessBoard),
+            this.jumpUpLeft(chessBoard),
+            this.jumpDownRight(chessBoard),
+            this.jumpDownLeft(chessBoard),
+            this.jumpRightUp(chessBoard),
+            this.jumpRightDown(chessBoard),
+            this.jumpLeftUp(chessBoard),
+            this.jumpLeftDown(chessBoard),
         ];
 
         // Filter out null moves (moves outside the chessboard)

--- a/src/pieces/pawn.js
+++ b/src/pieces/pawn.js
@@ -9,9 +9,11 @@ export class Pawn extends Piece {
 
     // Check if piece is infront of pawn
     moveForwardLimit(newRow, newCol, chessBoard) {
-        const tileCheck = chessBoard[newRow][newCol].spaceOccupation;
+        if (this.pieceBoundCheck(newRow, newCol)) {
+            const tileCheck = chessBoard[newRow][newCol].spaceOccupation;
        
-        return tileCheck ? false : true;
+            return tileCheck ? false : true;
+        }
     }
 
     // Standard pawn move
@@ -24,7 +26,7 @@ export class Pawn extends Piece {
 
         const invalidCheck = this.moveForwardLimit(newRow, newCol, chessBoard);
 
-        return invalidCheck ? this.pieceBoundCheck(newRow, newCol) : null;
+        return invalidCheck ? [newRow, newCol] : null;
     }
 
     // Beginning move
@@ -44,10 +46,12 @@ export class Pawn extends Piece {
 
     // Check whether tile is friendly or enemy
     checkCapturePossible(newRow, newCol, chessBoard) {
-        const tileCheck = chessBoard[newRow][newCol].spaceOccupation;
+        if (this.pieceBoundCheck(newRow, newCol)) {
+            const tileCheck = chessBoard[newRow][newCol].spaceOccupation;
 
-        if (tileCheck) {
-            return tileCheck.pieceTeam != this.team ? true : false;
+            if (tileCheck) {
+                return tileCheck.pieceTeam != this.team ? true : false;
+            }
         }
     }
 
@@ -60,7 +64,7 @@ export class Pawn extends Piece {
         const newCol = col + 1;
 
         const canCapture = this.checkCapturePossible(newRow, newCol, chessBoard);
-        return canCapture ? this.pieceBoundCheck(newRow, newCol) : null;
+        return canCapture ? [newRow, newCol] : null;
     }
 
     // Capture to diagonal left
@@ -72,7 +76,7 @@ export class Pawn extends Piece {
         const newCol = col - 1;
 
         const canCapture = this.checkCapturePossible(newRow, newCol, chessBoard);
-        return canCapture ? this.pieceBoundCheck(newRow, newCol) : null;
+        return canCapture ? [newRow, newCol] : null;
     }
 
     generateLegalMoves(chessBoard) {

--- a/src/pieces/pawn.js
+++ b/src/pieces/pawn.js
@@ -42,6 +42,15 @@ export class Pawn extends Piece {
         return this.pieceBoundCheck(newRow, newCol);
     }
 
+    // Check whether tile is friendly or enemy
+    checkCapturePossible(newRow, newCol, chessBoard) {
+        const tileCheck = chessBoard[newRow][newCol].spaceOccupation;
+
+        if (tileCheck) {
+            return tileCheck.pieceTeam != this.team ? true : false;
+        }
+    }
+
     // Capture to diagonal right
     captureRight(chessBoard) {
         const [row, col] = this._currentPosition;

--- a/src/pieces/pieces.js
+++ b/src/pieces/pieces.js
@@ -63,15 +63,6 @@ export class Piece {
         this._currentPosition = newPosition;
     }
 
-    // Check whether tile is friendly or enemy
-    checkCapturePossible(newRow, newCol, chessBoard) {
-        const tileCheck = chessBoard[newRow][newCol].spaceOccupation;
-
-        if (tileCheck) {
-            return tileCheck.pieceTeam != this.team ? true : false;
-        }
-    }
-
     // Edge Detection - Board check
     isInBounds(row, col) {
         return row >= 0 && row < 8 && col >= 0 && col < 8;
@@ -87,11 +78,7 @@ export class Piece {
 
     // Edge Detection - Initiate Check
     pieceBoundCheck(newRow, newCol) {
-        if (this.isInBounds(newRow, newCol)) {
-            return [newRow, newCol]
-        } else {
-            return null;
-        }
+        return this.isInBounds(newRow, newCol) ? [newRow, newCol] : null;
     }
 
     // Edge Detection Logic

--- a/src/pieces/pieces.js
+++ b/src/pieces/pieces.js
@@ -63,6 +63,18 @@ export class Piece {
         this._currentPosition = newPosition;
     }
 
+    // Check for friendlies
+    friendlyTileCheck(newRow, newCol, chessBoard) {
+        if (this.pieceBoundCheck(newRow, newCol)) {
+            const tileOccupation = chessBoard[newRow][newCol].spaceOccupation;
+
+            return tileOccupation && tileOccupation.pieceTeam === this.team;
+        }
+
+        // Return false if the position is out of bounds
+        return false;
+    }
+
     // Edge Detection - Board check
     isInBounds(row, col) {
         return row >= 0 && row < 8 && col >= 0 && col < 8;


### PR DESCRIPTION
Fixed all the movement errors in this fix. The issue that was occurring was that, pieces were generating pieces that were off the board. By adding the bound check from the get go prevents out of bound pieces being considered avoiding, invalid generations