### PR TITLE
CG-23 Included defended pieces in enemy moves

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,6 @@
     </head>
     <body id="body">
         <div id="popup-container">
-            <!-- Piece promotion options will be rendered here -->
         </div>
     </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ const tilePressed = async (tileCheck, event) => {
         initialSelectedPieceLocation = tileFullLocation(event);
         initialSelectedPiece = await pressedTile(event, chessBoard);
 
-        checkmate(initialSelectedPiece.pieceTeam, KINGS, chessBoard);
+        // checkmate(initialSelectedPiece.pieceTeam, KINGS, chessBoard);
     } else {
         await movePiece(initialSelectedPiece, initialSelectedPieceLocation, event, chessBoard);
         reRenderChessboard(chessBoard);

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ const tilePressed = async (tileCheck, event) => {
         initialSelectedPieceLocation = tileFullLocation(event);
         initialSelectedPiece = await pressedTile(event, chessBoard);
 
-        // checkmate(initialSelectedPiece.pieceTeam, KINGS, chessBoard);
+        checkmate(initialSelectedPiece.pieceTeam, KINGS, chessBoard);
     } else {
         await movePiece(initialSelectedPiece, initialSelectedPieceLocation, event, chessBoard);
         reRenderChessboard(chessBoard);

--- a/src/board/board.js
+++ b/src/board/board.js
@@ -3,7 +3,7 @@ const COLS = 8;
 const BLACK = 'bg-black';
 const WHITE = 'bg-white';
 
-class Tile {
+export class Tile {
     constructor(position, colour) {
         this._object = "Tile";
         this._position = position;

--- a/src/pieces/piece/king.js
+++ b/src/pieces/piece/king.js
@@ -1,7 +1,6 @@
 // king.js
 import { Piece } from "../pieces.js";
 import { kingCastle } from "../../util/castling.js";
-import { checkTestRun } from "../../util/checkmate/movingIntoCheck.js";
 
 export class King extends Piece {
     constructor(team, startingPosition) {

--- a/src/pieces/piece/king.js
+++ b/src/pieces/piece/king.js
@@ -1,6 +1,7 @@
 // king.js
 import { Piece } from "../pieces.js";
 import { kingCastle } from "../../util/castling.js";
+import { checkTestRun } from "../../util/checkmate/movingIntoCheck.js";
 
 export class King extends Piece {
     constructor(team, startingPosition) {
@@ -8,7 +9,12 @@ export class King extends Piece {
         this._inCheck = false;
         this._castleRightPos = null;
         this._castleLeftPos = null;
+        this._inCheckmate = null;
     }  
+
+    get checkmate() {
+        return this._inCheckmate;
+    }
 
     get rightCastle() {
         return this._castleRightPos;
@@ -24,6 +30,10 @@ export class King extends Piece {
     
     set leftCastle(newPos) {
         this._castleLeftPos = newPos;
+    }
+
+    set kingInCheckmate(check) {F
+        this._inCheckmate = check;
     }
     
     // Standard Moves

--- a/src/pieces/piece/pawn.js
+++ b/src/pieces/piece/pawn.js
@@ -11,6 +11,13 @@ export class Pawn extends Piece {
     moveForwardLimit(newRow, newCol, chessBoard) {
         if (this.pieceBoundCheck(newRow, newCol)) {
             const tileCheck = chessBoard[newRow][newCol].spaceOccupation;
+
+            // TODO: Global function
+            if (tileCheck && tileCheck.pieceTeam == this.team) {
+                if (!this._defendingPiece.some(piece => piece.id === tileCheck.id)) {
+                    this._defendingPiece.push(tileCheck);
+                }
+            }
        
             return tileCheck ? false : true;
         }
@@ -54,6 +61,13 @@ export class Pawn extends Piece {
     checkCapturePossible(newRow, newCol, chessBoard) {
         if (this.pieceBoundCheck(newRow, newCol)) {
             const tileCheck = chessBoard[newRow][newCol].spaceOccupation;
+
+            // TODO: Global this
+            if (tileCheck && tileCheck.pieceTeam == this.team) {
+                if (!this._defendingPiece.some(piece => piece.id === tileCheck.id)) {
+                    this._defendingPiece.push(tileCheck);
+                }
+            }
 
             if (tileCheck) {
                 return tileCheck.pieceTeam != this.team ? true : false;

--- a/src/util/checkmate/checkmate.js
+++ b/src/util/checkmate/checkmate.js
@@ -1,11 +1,11 @@
-const MAXPIECES = 16;
-const BOARDMAX = 8;
+export const MAXPIECES = 16;
+export const BOARDMAX = 8;
 
-const enemyOrFriendly = (piece, originalTeam) => {
+export const enemyOrFriendly = (piece, originalTeam) => {
     return piece.pieceTeam != originalTeam ? piece : undefined;
 }
 
-const pieceOrTile = (chessBoardTile) => {
+export const pieceOrTile = (chessBoardTile) => {
     return chessBoardTile.spaceOccupation;
 }
 
@@ -14,7 +14,7 @@ const kingInCheck = (kingPiece, validEnemyMoves) => {
 
     for (const moves of validEnemyMoves) {
         if (moves[0] == kingPosition[0] && moves[1] == kingPosition[1]) {
-                    return true;
+                return true;
         }
     }
 
@@ -36,12 +36,17 @@ const kingFutureMoves = (kingPiece, validEnemyMoves) => {
         }
     }
 
+    // TODO Remove Duplicates
     return checkmateCount >= kingMoveCount ? true : false;
 }
 
-const kingInCheckmate = (kingPiece, inCheckCheck, validEnemyMoves) => {
+const kingInCheckmate = (kingPiece, inCheckCheck, validEnemyMoves, originalTeam, chessBoard) => {
     if (inCheckCheck) {
-        return kingFutureMoves(kingPiece, validEnemyMoves);
+        // const moveIntoCheck = checkTestRun(kingPiece, originalTeam, kingPiece.getValidMoves, chessBoard);
+        kingPiece.simulateFutureMoves(chessBoard);
+        const checkmateMoves = kingFutureMoves(kingPiece, validEnemyMoves);
+
+        return checkmateMoves ? true : false;
     }
 }
 
@@ -56,7 +61,7 @@ const enemyThreats = (originalTeam, kingPiece, chessBoard) => {
             const piece = pieceOrTile(chessBoard[row][col]);
 
             if (piece) {
-                const enemyPiece = enemyOrFriendly(piece, originalTeam);
+                const enemyPiece = enemyOrFriendly(piece, originalKing);
 
                 if (enemyPiece) {
                     piecesFound++;
@@ -66,8 +71,10 @@ const enemyThreats = (originalTeam, kingPiece, chessBoard) => {
         }
     }
 
+    originalKing.generateLegalMoves(chessBoard);
+
     const inCheckCheck = kingInCheck(originalKing, validEnemyMoves);
-    const checkmateCheck = kingInCheckmate(originalKing, inCheckCheck, validEnemyMoves);
+    const checkmateCheck = kingInCheckmate(originalKing, inCheckCheck, validEnemyMoves, originalTeam, chessBoard);
 
     return {
         "check": inCheckCheck || null,

--- a/src/util/checkmate/movingIntoCheck.js
+++ b/src/util/checkmate/movingIntoCheck.js
@@ -1,0 +1,81 @@
+import { pieceOrTile, MAXPIECES, BOARDMAX, enemyOrFriendly } from './checkmate.js';
+import { Tile } from '../../board/board.js';
+
+// Copy original chessboard
+const updateTempChessboard = (kingPiece, originalRow, originalCol, targetRow, targetCol, tempChessboard) => {
+    tempChessboard[targetRow][targetCol] = new Tile;
+    tempChessboard[originalRow][originalCol] = new Tile;
+
+    tempChessboard[targetRow][targetCol].pieceInSpace = kingPiece;
+}
+
+const emptyTempboard = (tempBoard) => {
+    for (let row = 0; row < BOARDMAX; row++) {
+        for (let col = 0; col < BOARDMAX; col++) {
+            tempBoard[row][col] = null
+        }
+    }
+}
+
+const moveIntoCheckStatus = (potentialMove, tempEnemyMoves) => {
+    for (const enemyMoves of tempEnemyMoves) {
+        console.log(enemyMoves);
+        if (potentialMove[0] == enemyMoves[0] && potentialMove[1] == enemyMoves[1]) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+// Potential Captures
+const enemyPotentialMoves = (originalTeam, kingPotentialMove, tempBoard) => {
+    let piecesFound = 0;
+    const tempEnemyMoves = [];
+
+
+    for (let row = 0; row < BOARDMAX && piecesFound < MAXPIECES; row++) {
+        for (let col = 0; col < BOARDMAX; col++) {
+            const piece = pieceOrTile(tempBoard[row][col]);
+
+            if (piece) {
+                const enemyPiece = enemyOrFriendly(piece, originalTeam);
+
+                if (enemyPiece) {
+                    piecesFound++;
+                    tempEnemyMoves.push(...enemyPiece.generateLegalMoves(tempBoard));
+                }   
+            }
+        }
+    }
+
+    return moveIntoCheckStatus(kingPotentialMove, tempEnemyMoves);
+}   
+
+
+// Play test
+const testRunPotentialMoves = (kingPiece, originalTeam, potentialMove, chessBoard) => {
+    const tempBoard = chessBoard.map(row => row.slice());
+    const [originalRow, originalCol] = kingPiece.getCurrentPosition;
+    const [targetRow, targetCol] = potentialMove;
+
+    updateTempChessboard(kingPiece, originalRow, originalCol, targetRow, targetCol, tempBoard);
+
+    const movingIntoCheckStatus = enemyPotentialMoves(originalTeam, potentialMove, tempBoard);
+
+    emptyTempboard(tempBoard);
+
+    return movingIntoCheckStatus ? true : false;
+}
+
+// Initiate Test Place
+export const checkTestRun = (kingPiece, originalTeam, kingPotentialMove, chessBoard) => {
+    const movingIntoCheck = testRunPotentialMoves(kingPiece, originalTeam, kingPotentialMove, chessBoard);
+
+    if (movingIntoCheck) {
+        console.log("Will be moving into check");
+        return true;
+    }
+
+    return false;
+}

--- a/src/util/movement/movePiece.js
+++ b/src/util/movement/movePiece.js
@@ -35,6 +35,7 @@ const pressedSameTile = (destinationTile, initialPiece) => {
 export const movePiece = async (initialSelectedPiece, initialSelectedPieceLocation, moveToTile, chessBoard) => {
     // Object - Tile or a Pawn
     const destinationTilePiece = await pressedTile(moveToTile, chessBoard);
+    initialSelectedPiece.resetProtected = [];
 
     if (pressedSameTile(destinationTilePiece, initialSelectedPiece)) {
         console.log("Pressed on the same tile");


### PR DESCRIPTION
I have now implemented the logic to see whether the king is in checkmate and check.

Added a new array called defended pieces, which keeps track of pieces that are being defend. With this I managed to deal with the situation where the generated legal moves wasn't taking into consideration enemy moves, that were defending pieces.

Might need to do some refactoring, and clean up but it now works as expected.