### PR TITLE
CG-26 King can't move into Pawn capture moves

### DIFF
--- a/src/pieces/piece/pawn.js
+++ b/src/pieces/piece/pawn.js
@@ -5,6 +5,12 @@ import { indexToLocation } from "../../util/pieceTileLocation.js";
 export class Pawn extends Piece {
     constructor(team, startingPosition) {
         super("Pawn", team, startingPosition);
+        this._storeCaptureMoves = [];
+    }
+
+    // Get capture moves to prevent King movemnets
+    get pawnCaptureTiles() {
+        return this._storeCaptureMoves;
     }
 
     // Standard pawn move
@@ -48,6 +54,7 @@ export class Pawn extends Piece {
     // Check whether tile is friendly or enemy
     checkCapturePossible(newRow, newCol, chessBoard) {
         if (this.pieceBoundCheck(newRow, newCol)) {
+            this._storeCaptureMoves.push([newRow, newCol]);
             const tileCheck = chessBoard[newRow][newCol].spaceOccupation;
 
             if (tileCheck) {

--- a/src/util/allEnemyAttackIndexes.js
+++ b/src/util/allEnemyAttackIndexes.js
@@ -17,6 +17,9 @@ export const allEnemyMoves = (currentTeamTurn, chessBoard) => {
     const enemyMoves = [];
 
     for (const enemy of enemyPieces) {
+        if (enemy.getPieceName === "Pawn") {
+            enemyMoves.push(...enemy.pawnCaptureTiles)
+        }
         if (enemy.getValidMoves.length !== 0 && enemy.getPieceName != "King") {  // TODO: Need to adjust this. Becareful of recursion
             enemyMoves.push(...enemy.generateLegalMoves(chessBoard));
 


### PR DESCRIPTION
Added the logic which prevents King from moving into Pawn capture positions. Added Pawn capture tiles, into a separate array, and added that independently into allEnemyMoves. That move is now considered when generating moves for the King.