### PR TITLE
CG-32 Fixed Kings can't move into surrounding tiles

### DIFF
--- a/src/pieces/piece/king.js
+++ b/src/pieces/piece/king.js
@@ -9,7 +9,7 @@ export class King extends Piece {
         this._castleRightPos = null;
         this._castleLeftPos = null;
         this._inCheckmate = null;
-        this._savedPotentialMoves = [];
+        this._surroundingTiles = [];
     }  
 
     // Return whether king is in checkmate or not
@@ -17,18 +17,24 @@ export class King extends Piece {
         return this._inCheckmate;
     }
 
+    // Return surrounding tiles
+    get surroundingTiles() {
+        return this._surroundingTiles;
+    }
+
     // Return location of castle on right hand side
     get rightCastle() {
         return this._castleRightPos;
     }
 
-    get kingPotentialMoves() {
-        return this._savedPotentialMoves;
-    }
-
     // Return location of castle on left hand side
     get leftCastle() {
         return this._castleLeftPos;
+    }
+
+    // Reset the surrounding tiles
+    set surroundingTiles(empty) {
+        this._surroundingTiles = empty;
     }
 
     set kingPotentialMoves(filteredMoves) {
@@ -54,6 +60,10 @@ export class King extends Piece {
 
     // Legal moves for the king
     kingValidMoves(newRow, newCol, chessBoard) {
+
+        const surroundingTile = this.pieceBoundCheck(newRow, newCol);
+        this._surroundingTiles.push(surroundingTile);
+
         return (
             !this.friendlyTileCheck(newRow, newCol, chessBoard) &&
             this.pieceBoundCheck(newRow, newCol) &&
@@ -105,6 +115,8 @@ export class King extends Piece {
 
     // Generate all legal moves for the king
     generateLegalMoves(chessBoard) {
+        this.surroundingTiles = [];
+
         const legalMoves = [
             this.moveUp(chessBoard),
             this.moveDown(chessBoard),
@@ -117,10 +129,6 @@ export class King extends Piece {
             this.castlingRight(chessBoard),
             this.castlingLeft(chessBoard)
         ];
-
-        // TODO: Only one king will generate the legal move of the other
-
-        // this.kingPotentialMoves = legalMoves;
 
         return this.filterTiles(legalMoves, this);
     }

--- a/src/pieces/piece/pawn.js
+++ b/src/pieces/piece/pawn.js
@@ -9,8 +9,13 @@ export class Pawn extends Piece {
     }
 
     // Get capture moves to prevent King movemnets
-    get pawnCaptureTiles() {
+    get storeCaptureMoves() {
         return this._storeCaptureMoves;
+    }
+
+    // Reset capture move
+    set storeCaptureMoves(empty) {
+        this._storeCaptureMoves = empty;
     }
 
     // Standard pawn move
@@ -72,8 +77,6 @@ export class Pawn extends Piece {
         const newRow = row + this.direction;
         const newCol = col + colDelta;
 
-        console.log(newRow, newCol)
-
         const canCapture = this.checkCapturePossible(newRow, newCol, chessBoard);
         return canCapture ? [newRow, newCol] : null;
     }
@@ -97,6 +100,8 @@ export class Pawn extends Piece {
     }
 
     generateLegalMoves(chessBoard) {
+        this._storeCaptureMoves = [];
+
         const legalMoves = [
             this.moveForwardOnce(chessBoard),
             this.moveForwardTwice(chessBoard),

--- a/src/util/allEnemyAttackIndexes.js
+++ b/src/util/allEnemyAttackIndexes.js
@@ -21,16 +21,23 @@ export const allEnemyMoves = (currentTeamTurn, chessBoard) => {
     const enemyMoves = [];
 
     for (const enemy of enemyPieces) {
+        // Specific piece invalid moves
         if (enemy.getPieceName === "Pawn") {
-            enemyMoves.push(...enemy.pawnCaptureTiles)
+            enemyMoves.push(...enemy.storeCaptureMoves)
+        } else if (enemy.getPieceName === "King") {
+            enemyMoves.push(...enemy.surroundingTiles)
         }
+
+        // General piece moves
         if (enemy.getValidMoves.length !== 0 && enemy.getPieceName != "King") {  // TODO: Need to adjust this. Becareful of recursion
             enemyMoves.push(...enemy.generateLegalMoves(chessBoard));
 
-            if (enemy.defendingPieces.length !== 0) {
-                enemyMoves.push(...enemyDefendingMoves(enemy));
-            }
-        }   
+        }
+
+        // Pieces that being defended
+        if (enemy.defendingPieces.length !== 0) {
+            enemyMoves.push(...enemyDefendingMoves(enemy));
+        }
     }
 
     return enemyMoves;


### PR DESCRIPTION
Fixed issue where one King can move into the other kings surrounding tiles. Created an attribute that stores surrounding moves, and adds it to all enemy moves. So now both Kings can't move into each others surrounding tiles.